### PR TITLE
corrected the debug level range.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -48,7 +48,7 @@ Convenience method to get the first device with the specified VID and PID, or `u
 Constant properties from libusb
 
 ### usb.setDebugLevel(level : int)
-Set the libusb debug level (between 0 and 4)
+Set the libusb debug level (between 0 and 3)
 
 Device
 ------


### PR DESCRIPTION
Because:

```
usb.setDebugLevel(4);
    ^
TypeError: Usb::SetDebugLevel argument is invalid. [uint:[0-3]]!
```
