### PR TITLE
Reverts changes made in 1.2.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,11 @@
   },
   "binary": {
     "module_name": "usb_bindings",
-    "module_path": "build/bindings",
+    "module_path": "./src/binding",
     "host": "https://github.com/tessel/node-usb/releases/download/",
     "remote_path": "{version}"
   },
   "dependencies": {
-    "bindings": "^1.2.1",
     "nan": "^2.4.0",
     "node-pre-gyp": "^0.6.30"
   },

--- a/package.json
+++ b/package.json
@@ -45,9 +45,6 @@
     "nan": "^2.4.0",
     "node-pre-gyp": "^0.6.30"
   },
-  "bundledDependencies": [
-    "node-pre-gyp"
-  ],
   "devDependencies": {
     "coffee-script": "~1.6.2",
     "mocha": "~1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "usb",
   "description": "Library to access USB devices",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "engines": {
     "node": ">=0.12.x"
   },

--- a/usb.js
+++ b/usb.js
@@ -1,4 +1,8 @@
-var usb = exports = module.exports = require('bindings')('usb_bindings.node');
+var binary = require('node-pre-gyp');
+var path = require('path');
+var binding_path = binary.find(path.resolve(path.join(__dirname,'./package.json')));
+
+var usb = exports = module.exports = require(binding_path);
 var events = require('events')
 var util = require('util')
 


### PR DESCRIPTION
Changing the bindings path to be found by the `bindings` module led to several issues for loading bindings on Windows. We can revisit this at a later time.