### PR TITLE
Always use system libusb on FreeBSD

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -35,12 +35,12 @@
       ],
 
       'conditions' : [
-          ['use_system_libusb=="false"', {
+          ['use_system_libusb=="false" and OS!="freebsd"', {
             'dependencies': [
               'libusb.gypi:libusb',
             ],
           }],
-          ['use_system_libusb=="true"', {
+          ['use_system_libusb=="true" or OS=="freebsd"', {
             'include_dirs+': [
               '<!@(pkg-config libusb-1.0 --cflags-only-I | sed s/-I//g)'
             ],

--- a/src/device.cc
+++ b/src/device.cc
@@ -81,30 +81,25 @@ static NAN_METHOD(deviceConstructor) {
 	STRUCT_TO_V8(v8dd, dd, bNumConfigurations)
 
 	uint8_t port_numbers[MAX_PORTS];
-	// FreeBSD workarounds based on https://sourceforge.net/p/sigrok/mailman/attachment/54C11DD2.10002%40uffe.org/1/
-#ifdef __FreeBSD__
-	struct libusb_device_handle* dh;
-	CHECK_USB(libusb_open(self->device, &dh));
-#endif
 	int ret = libusb_get_port_numbers(self->device, &port_numbers[0], MAX_PORTS);
+	if (ret >= 0) {
+		Local<Array> array = Nan::New<Array>(ret);
+		for (int i = 0; i < ret; ++ i) {
+			array->Set(i, Nan::New(port_numbers[i]));
+		}
+		info.This()->ForceSet(V8SYM("portNumbers"), array, CONST_PROP);
+	} else {
+		// FreeBSD workarounds based on https://sourceforge.net/p/sigrok/mailman/attachment/54C11DD2.10002%40uffe.org/1/
 #ifdef __FreeBSD__
-	if (ret <= 0) {
+		struct libusb_device_handle* dh;
+		CHECK_USB(libusb_open(self->device, &dh));
 		Local<Array> array = Nan::New<Array>(1);
 		array->Set(0, Nan::New(libusb_get_device_address(self->device)));
 		info.This()->ForceSet(V8SYM("portNumbers"), array, CONST_PROP);
-	} else {
+		libusb_close(dh);
 #endif
-	CHECK_USB(ret);
-	Local<Array> array = Nan::New<Array>(ret);
-	for (int i = 0; i < ret; ++ i) {
-		array->Set(i, Nan::New(port_numbers[i]));
+		// If get_port_numbers fails on other platforms, just don't set the property
 	}
-	info.This()->ForceSet(V8SYM("portNumbers"), array, CONST_PROP);
-#ifdef __FreeBSD__
-	}
-	libusb_close(dh);
-#endif
-
 	info.GetReturnValue().Set(info.This());
 }
 


### PR DESCRIPTION
Upstream libusb does not support FreeBSD. (Even though it does support OpenBSD, NetBSD and even Haiku.)

All tests passed on my FreeBSD machine!