### PR TITLE
Simplify device object pinning logic

### DIFF
--- a/src/node_usb.h
+++ b/src/node_usb.h
@@ -35,10 +35,9 @@ struct Device: public Nan::ObjectWrap {
 	inline void attach(Local<Object> o){Wrap(o);}
 
 	~Device();
-	static void unpin(libusb_device* device);
 
 	protected:
-		static std::map<libusb_device*, Nan::Persistent<Object>> byPtr;
+		static std::map<libusb_device*, Device*> byPtr;
 		Device(libusb_device* d);
 };
 


### PR DESCRIPTION
V8 sometimes didn't call the WeakCallback on the Persistent before
destroying the object, leaving a destroyed object in the pin table.

Fixes #156