### PR TITLE
addition of variables, module_name and module_path

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,8 @@
   'variables': {
     'use_udev%': 1,
     'use_system_libusb%': 'false',
+    'module_name': 'usb_bindings', 
+    'module_path': './src/usb_binding'
   },
   'targets': [
     {


### PR DESCRIPTION
Windows 10 
gyp info it worked if it ends with ok
gyp info using node-gyp@3.5.0
gyp info using node@6.8.1 | win32 | x64

  C:\Users\owen\.node-gyp\6.8.1\include\node\v8.h(8202): note: see declaration of 'v8::Value::ToInt32'
     Creating library C:\source\repos\github\tessel\node-usb\build\Release\usb_bindings.lib and object C:\source\repos\
  github\tessel\node-usb\build\Release\usb_bindings.exp
  Generating code
  Finished generating code
  usb_bindings.vcxproj -> C:\source\repos\github\tessel\node-usb\build\Release\\usb_bindings.node
  usb_bindings.vcxproj -> C:\source\repos\github\tessel\node-usb\build\Release\usb_bindings.pdb (Full PDB)
  Copying C:\source\repos\github\tessel\node-usb\build\Release\/usb_bindings.node to ./src/usb_binding\usb_bindings.nod
  e
          1 file(s) copied.
gyp info ok