### PR TITLE
Make callback argument in controlTransfer completely optional

### DIFF
--- a/usb.js
+++ b/usb.js
@@ -122,7 +122,9 @@ function(bmRequestType, bRequest, wValue, wIndex, data_or_length, callback){
 	try {
 		transfer.submit(buf)
 	} catch (e) {
-		process.nextTick(function() { callback.call(self, e); });
+		if (callback){
+			process.nextTick(function() { callback.call(self, e); });
+		}
 	}
 	return this;
 }


### PR DESCRIPTION
[Line 112](https://github.com/tessel/node-usb/blob/master/usb.js#L112) suggests that the callback argument to the [controlTransfer](https://github.com/tessel/node-usb/blob/master/usb.js#L79) function is optional.

However, in case of an error the callback is [called](https://github.com/tessel/node-usb/blob/master/usb.js#L125) unconditionally.

Fixes #155 