### PR TITLE
Check version before __getBosDescriptor (#211)

### DIFF
--- a/usb.js
+++ b/usb.js
@@ -62,6 +62,9 @@ Object.defineProperty(usb.Device.prototype, "configDescriptor", {
 
 Object.defineProperty(usb.Device.prototype, "bosDescriptor", {
 	get: function() {
+		if (this.deviceDescriptor.bcdUSB < 0x201){
+			return null;
+		}
 		try {
 			return this._bosDescriptor || (this._bosDescriptor = this.__getBosDescriptor())
 		} catch(e) {


### PR DESCRIPTION
This fixes #211 on my USB 1.1 device which disconnects on calls to libusb_get_device_descriptor.

Based on similar version checking in libusb examples e.g. https://github.com/libusb/libusb/blob/b4c9b4272d61cecffeddeb91abd31efe256a6224/examples/testlibusb.c#L236