### PR TITLE
Do not call kernel driver functionality when running on win32

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -159,13 +159,13 @@ Releases the interface and resets the alternate setting. Calls callback when com
 It is an error to release an interface with pending transfers. If the optional closeEndpoints parameter is true, any active endpoint streams are stopped (see `Endpoint.stopStream`), and the interface is released after the stream transfers are cancelled. Transfers submitted individually with `Endpoint.transfer` are not affected by this parameter.
 
 ### .isKernelDriverActive()
-Returns `false` if a kernel driver is not active; `true` if active.
+Returns `false` if a kernel driver is not active; `true` if active. In Windows systems, this will always be `false`.
 
 ### .detachKernelDriver()
-Detaches the kernel driver from the interface.
+Detaches the kernel driver from the interface. Ignored in Windows systems.
 
 ### .attachKernelDriver()
-Re-attaches the kernel driver for the interface.
+Re-attaches the kernel driver for the interface. Ignored in Windows systems.
 
 ### .descriptor
 Object with fields from the interface descriptor -- see libusb documentation or USB spec.

--- a/usb.js
+++ b/usb.js
@@ -216,16 +216,18 @@ Interface.prototype.release = function(closeEndpoints, cb){
 	}
 }
 
+var isNotWindows = (process.platform !== 'win32');
+
 Interface.prototype.isKernelDriverActive = function(){
-	return this.device.__isKernelDriverActive(this.id)
+	return isNotWindows && this.device.__isKernelDriverActive(this.id)
 }
 
 Interface.prototype.detachKernelDriver = function() {
-	return this.device.__detachKernelDriver(this.id)
+	return isNotWindows && this.device.__detachKernelDriver(this.id)
 };
 
 Interface.prototype.attachKernelDriver = function() {
-	return this.device.__attachKernelDriver(this.id)
+	return isNotWindows && this.device.__attachKernelDriver(this.id)
 };
 
 


### PR DESCRIPTION
I've been hit by #147, and I think that a nicer approach would be to just skip calls to `__isKernelDriverActive`, `__detachKernelDriver` and `__attachKernelDriver` when running on a win32 platform.

This PR does that, and makes a brief note in the readme.

(The use case is a [JS implementation of USB CDC ACM](https://www.npmjs.com/package/usb-cdc-acm) which, in fact, has to detach the `cdc-acm` kernel driver)

