### PR TITLE
Allow loading module in environments without usb

### DIFF
--- a/src/node_usb.cc
+++ b/src/node_usb.cc
@@ -84,8 +84,8 @@ extern "C" void Initialize(Local<Object> target) {
 	Device::Init(target);
 	Transfer::Init(target);
 
-	Nan::SetMethod(target, "setDebugLevel", SetDebugLevel);
-	Nan::SetMethod(target, "getDeviceList", GetDeviceList);
+	Nan::SetMethod(target, "_setDebugLevel", SetDebugLevel);
+	Nan::SetMethod(target, "_getDeviceList", GetDeviceList);
 	Nan::SetMethod(target, "_enableHotplugEvents", EnableHotplugEvents);
 	Nan::SetMethod(target, "_disableHotplugEvents", DisableHotplugEvents);
 	initConstants(target);

--- a/usb.js
+++ b/usb.js
@@ -6,9 +6,11 @@ var usb = exports = module.exports = require(binding_path);
 var events = require('events')
 var util = require('util')
 
-// Check that libusb was initialized.
-if (usb.INIT_ERROR) {
-	throw new Error('Could not initialize libusb. Check that your system has a usb controller.');
+function ensureLibusbInitialized() {
+	// Check that libusb was initialized.
+	if (usb.INIT_ERROR) {
+		throw new Error('Could not initialize libusb. Check that your system has a usb controller.');
+	}
 }
 
 Object.keys(events.EventEmitter.prototype).forEach(function (key) {
@@ -17,6 +19,7 @@ Object.keys(events.EventEmitter.prototype).forEach(function (key) {
 
 // convenience method for finding a device by vendor and product id
 exports.findByIds = function(vid, pid) {
+	ensureLibusbInitialized()
 	var devices = usb.getDeviceList()
 
 	for (var i = 0; i < devices.length; i++) {
@@ -30,6 +33,7 @@ exports.findByIds = function(vid, pid) {
 usb.Device.prototype.timeout = 1000
 
 usb.Device.prototype.open = function(defaultConfig){
+	ensureLibusbInitialized()
 	this.__open()
 	if (defaultConfig === false) return
 	this.interfaces = []
@@ -160,6 +164,7 @@ usb.Device.prototype.setConfiguration = function(desired, cb) {
 }
 
 function Interface(device, id){
+	ensureLibusbInitialized()
 	this.device = device
 	this.id = id
 	this.altSetting = 0;
@@ -250,6 +255,7 @@ Interface.prototype.endpoint = function(addr){
 }
 
 function Endpoint(device, descriptor){
+	ensureLibusbInitialized()
 	this.device = device
 	this.descriptor = descriptor
 	this.address = descriptor.bEndpointAddress

--- a/usb.js
+++ b/usb.js
@@ -17,6 +17,14 @@ Object.keys(events.EventEmitter.prototype).forEach(function (key) {
 	exports[key] = events.EventEmitter.prototype[key];
 });
 
+exports.setDebugLevel = function(level) {
+	return usb._setDebugLevel(level);
+}
+
+exports.getDeviceList = function() {
+	return usb._getDeviceList();
+}
+
 // convenience method for finding a device by vendor and product id
 exports.findByIds = function(vid, pid) {
 	ensureLibusbInitialized()

--- a/usb.js
+++ b/usb.js
@@ -18,16 +18,17 @@ Object.keys(events.EventEmitter.prototype).forEach(function (key) {
 });
 
 exports.setDebugLevel = function(level) {
+	ensureLibusbInitialized();
 	return usb._setDebugLevel(level);
 }
 
 exports.getDeviceList = function() {
+	ensureLibusbInitialized();
 	return usb._getDeviceList();
 }
 
 // convenience method for finding a device by vendor and product id
 exports.findByIds = function(vid, pid) {
-	ensureLibusbInitialized()
 	var devices = usb.getDeviceList()
 
 	for (var i = 0; i < devices.length; i++) {
@@ -41,7 +42,6 @@ exports.findByIds = function(vid, pid) {
 usb.Device.prototype.timeout = 1000
 
 usb.Device.prototype.open = function(defaultConfig){
-	ensureLibusbInitialized()
 	this.__open()
 	if (defaultConfig === false) return
 	this.interfaces = []
@@ -172,7 +172,6 @@ usb.Device.prototype.setConfiguration = function(desired, cb) {
 }
 
 function Interface(device, id){
-	ensureLibusbInitialized()
 	this.device = device
 	this.id = id
 	this.altSetting = 0;
@@ -263,7 +262,6 @@ Interface.prototype.endpoint = function(addr){
 }
 
 function Endpoint(device, descriptor){
-	ensureLibusbInitialized()
 	this.device = device
 	this.descriptor = descriptor
 	this.address = descriptor.bEndpointAddress
@@ -411,10 +409,16 @@ OutEndpoint.prototype.transferWithZLP = function (buf, cb) {
 var hotplugListeners = 0;
 exports.on('newListener', function(name) {
 	if (name !== 'attach' && name !== 'detach') return;
-	if (++hotplugListeners === 1) usb._enableHotplugEvents();
+	if (++hotplugListeners === 1) {
+		ensureLibusbInitialized();
+		usb._enableHotplugEvents();
+	}
 });
 
 exports.on('removeListener', function(name) {
 	if (name !== 'attach' && name !== 'detach') return;
-	if (--hotplugListeners === 0) usb._disableHotplugEvents();
+	if (--hotplugListeners === 0) {
+		ensureLibusbInitialized();
+		usb._disableHotplugEvents();
+	}
 });


### PR DESCRIPTION
e.g. CI system.

This throws an exception when USB is not available only when used, not when module is loaded.

Check currently happens

* in findByIds()
* in Device.open()
* in Interface constructor
* in Endpoint constructor

Please let me know if those places should be reduced or expanded. I am not an expert of USB.

Closes #194