### PR TITLE
Fix travis build status badge and link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,8 @@
 USB Library for Node.JS
 ===============================
 
-**POSIX:** [![Build Status](https://travis-ci.org/nonolith/node-usb.svg?branch=tcr-usb)](https://travis-ci.org/nonolith/node-usb) &nbsp;&nbsp;&nbsp; **Windows:** [![Build status](https://ci.appveyor.com/api/projects/status/b23kn1pi386nguya/branch/master)](https://ci.appveyor.com/project/kevinmehall/node-usb/branch/master)
+**POSIX:** [![Build Status](https://travis-ci.org/tessel/node-usb.svg?branch=master)](https://travis-ci.org/tessel/node-usb) &nbsp;&nbsp;&nbsp;
+**Windows:** [![Build status](https://ci.appveyor.com/api/projects/status/b23kn1pi386nguya/branch/master)](https://ci.appveyor.com/project/kevinmehall/node-usb/branch/master)
 
 Node.JS library for communicating with USB devices in JavaScript / CoffeeScript.
 


### PR DESCRIPTION
Appveyor badge is probably wrong as well (at least the link is). But I cannot change it because AppVeyor badges include a unique token that is only available for the maintainers (https://www.appveyor.com/docs/status-badges/) 