### PR TITLE
add support for clearHalt on endpoints

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -208,6 +208,9 @@ Object with fields from the endpoint descriptor -- see libusb documentation or U
 ### .timeout
 Sets the timeout in milliseconds for transfers on this endpoint. The default, `0`, is infinite timeout.
 
+### .clearHalt(callback(error))
+Clear the halt/stall condition for this endpoint.
+
 InEndpoint
 ----------
 

--- a/usb.js
+++ b/usb.js
@@ -264,6 +264,10 @@ util.inherits(Endpoint, events.EventEmitter)
 
 Endpoint.prototype.timeout = 0
 
+Endpoint.prototype.clearHalt = function(callback){
+	return this.device.__clearHalt(this.address, callback);
+}
+
 Endpoint.prototype.makeTransfer = function(timeout, callback){
 	return new usb.Transfer(this.device, this.address, this.transferType, timeout, callback)
 }


### PR DESCRIPTION
add support for clearHalt on endpoints. This will issue a libusb_clear_halt call for the given endpoint.

Endpoints with halt status are unable to receive or transmit data until the halt condition is cleared.