### PR TITLE
fix endpoint polling status check

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -238,7 +238,7 @@ is called once all transfers have completed or canceled.
 Emitted with data received by the polling transfers
 
 ### Event: error(error)
-Emitted when polling encounters an error.
+Emitted when polling encounters an error. All in flight transfers will be automatically canceled and no further polling will be done. You have to wait for the `end` event before you can start polling again.
 
 ### Event: end
 Emitted when polling has been canceled

--- a/usb.js
+++ b/usb.js
@@ -342,6 +342,7 @@ InEndpoint.prototype.startPoll = function(nTransfers, transferSize){
 			self.pollPending--
 
 			if (self.pollPending == 0){
+				delete self.pollTransfers;
 				self.emit('end')
 			}
 		}


### PR DESCRIPTION
If you call startPoll, stopPoll & startPool on an endpoint you will always get a "Polling already active" exception because the polling state is not properly checked.

This resolves #249