### PR TITLE
Pin nan to 2.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,11 @@
     "remote_path": "{version}"
   },
   "dependencies": {
-    "nan": "^2.8.0",
+    "nan": "2.11.1",
     "node-pre-gyp": "^0.11.0"
+  },
+  "resolutions": {
+    "**/nan": "2.11.1"
   },
   "devDependencies": {
     "coffeescript": "~1.6.2",


### PR DESCRIPTION
Fixes issues like https://github.com/tessel/node-usb/issues/264 when building `node-usb` binaries for the latest Electron version (Reference: https://github.com/electron/electron/issues/16120#issuecomment-448136340). I've confirmed this works locally and built a quick hello-world electron project with node-usb. 