### PR TITLE
Making module work with Node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 
 env:
   global:
-  - PREBUILD_TARGETS="6.0.0 8.0.0 10.0.0 11.0.0"
+  - PREBUILD_TARGETS="6.0.0 8.0.0 10.0.0 11.0.0 12.0.0"
   - PREBUILD_ELECTRON_TARGETS="3.0.0 4.0.0 4.0.4"
   matrix:
   - ARCH="x64"

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
   },
   "dependencies": {
     "bindings": "^1.4.0",
-    "nan": "2.11.1",
+    "nan": "2.13.2",
     "prebuild-install": "^5.2.4"
   },
   "resolutions": {
-    "**/nan": "2.11.1"
+    "**/nan": "2.13.2"
   },
   "devDependencies": {
     "coffeescript": "~1.6.2",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "scripts": {
     "install": "prebuild-install --verbose || node-gyp rebuild",
     "prebuild": "prebuild --force --strip --verbose",
-    "test": "mocha --compilers coffee:coffeescript --grep Module",
-    "full-test": "mocha --compilers coffee:coffeescript",
+    "test": "mocha --require coffeescript/register --grep Module test/*",
+    "full-test": "mocha --require coffeescript/register test/*",
     "valgrind": "coffee -c test/usb.coffee; valgrind --leak-check=full --show-possibly-lost=no node --expose-gc --trace-gc node_modules/mocha/bin/_mocha -R spec"
   },
   "dependencies": {
@@ -45,8 +45,8 @@
     "**/nan": "2.13.2"
   },
   "devDependencies": {
-    "coffeescript": "~1.6.2",
-    "mocha": "~1.8.2",
+    "coffeescript": "~2.4.1",
+    "mocha": "~6.1.4",
     "prebuild": "=8.1.2"
   },
   "license": "MIT"

--- a/src/device.cc
+++ b/src/device.cc
@@ -36,7 +36,7 @@ Local<Object> Device::get(libusb_device* dev){
 	} else {
 		Local<FunctionTemplate> constructorHandle = Nan::New<v8::FunctionTemplate>(device_constructor);
 		Local<Value> argv[1] = { EXTERNAL_NEW(new Device(dev)) };
-		Local<Object> obj = Nan::NewInstance(constructorHandle->GetFunction(), 1, argv).ToLocalChecked();
+		Local<Object> obj = Nan::NewInstance(Nan::GetFunction(constructorHandle).ToLocalChecked(), 1, argv).ToLocalChecked();
 		return obj;
 	}
 }
@@ -412,5 +412,5 @@ void Device::Init(Local<Object> target){
 	Nan::SetPrototypeMethod(tpl, "__attachKernelDriver", AttachKernelDriver);
 
 	device_constructor.Reset(tpl);
-	target->Set(Nan::New("Device").ToLocalChecked(), tpl->GetFunction());
+	target->Set(Nan::New("Device").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
 }

--- a/src/node_usb.cc
+++ b/src/node_usb.cc
@@ -96,11 +96,11 @@ NODE_MODULE(usb_bindings, Initialize)
 
 NAN_METHOD(SetDebugLevel) {
 	Nan::HandleScope scope;
-	if (info.Length() != 1 || !info[0]->IsUint32() || info[0]->Uint32Value() > 4) {
+	if (info.Length() != 1 || !info[0]->IsUint32() || Nan::To<v8::Uint32>(info[0]).ToLocalChecked()->Value() > 4) {
 		THROW_BAD_ARGS("Usb::SetDebugLevel argument is invalid. [uint:[0-4]]!")
 	}
 
-	libusb_set_debug(usb_context, info[0]->Uint32Value());
+	libusb_set_debug(usb_context, Nan::To<v8::Uint32>(info[0]).ToLocalChecked()->Value());
 	info.GetReturnValue().Set(Nan::Undefined());
 }
 
@@ -297,7 +297,6 @@ void initConstants(Local<Object> target){
 
 Local<Value> libusbException(int errorno) {
 	const char* err = libusb_error_name(errorno);
-	Local<Value> e  = Nan::Error(err);
-	e->ToObject()->Set(Nan::New<String>("errno").ToLocalChecked(), Nan::New<Integer>(errorno));
+	Local<Value> e  = Nan::ErrnoException(errorno, NULL, err, NULL);
 	return e;
 }

--- a/src/node_usb.cc
+++ b/src/node_usb.cc
@@ -297,6 +297,7 @@ void initConstants(Local<Object> target){
 
 Local<Value> libusbException(int errorno) {
 	const char* err = libusb_error_name(errorno);
-	Local<Value> e  = Nan::ErrnoException(errorno, NULL, err, NULL);
+	Local<Value> e  = Nan::Error(err);
+	e.As<v8::Object>()->Set(Nan::New<String>("errno").ToLocalChecked(), Nan::New<Integer>(errorno));
 	return e;
 }

--- a/src/transfer.cc
+++ b/src/transfer.cc
@@ -55,7 +55,7 @@ NAN_METHOD(Transfer_Submit) {
 	if (!Buffer::HasInstance(info[0])){
 		THROW_BAD_ARGS("Buffer arg [0] must be Buffer");
 	}
-	Local<Object> buffer_obj = info[0]->ToObject();
+	Local<Object> buffer_obj = Nan::To<v8::Object>(info[0]).ToLocalChecked();
 	if (!self->device->device_handle){
 		THROW_ERROR("Device is not open");
 	}
@@ -153,5 +153,5 @@ void Transfer::Init(Local<Object> target){
 	Nan::SetPrototypeMethod(tpl, "submit", Transfer_Submit);
 	Nan::SetPrototypeMethod(tpl, "cancel", Transfer_Cancel);
 
-	target->Set(Nan::New("Transfer").ToLocalChecked(), tpl->GetFunction());
+	target->Set(Nan::New("Transfer").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
 }


### PR DESCRIPTION
The changes required 2 parts:

* the first commit needed updates to the abstraction layer, as there are a number calls that are now deprecated on Node 12. Updated the code to use Nan properly for those lines as well, and thus work for all Node versions.
* the very old mocha didn't work on Node 12 (did not run any tests), thus bumping version and update the test calls allows tests work on all Node versions as well.

As an extra, also updated Travis config building for Node 12.0.0 as well.