### PR TITLE
Add prebuild for Electron 6.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 env:
   global:
   - PREBUILD_TARGETS="6.0.0 8.0.0 10.0.0 11.0.0 12.0.0"
-  - PREBUILD_ELECTRON_TARGETS="3.0.0 4.0.0 4.0.4 5.0.0"
+  - PREBUILD_ELECTRON_TARGETS="3.0.0 4.0.0 4.0.4 5.0.0 6.0.0"
   matrix:
   - ARCH="x64"
   - ARCH="ia32"


### PR DESCRIPTION
Electron 6.0.0 was released a few days ago.

https://electronjs.org/blog/electron-6-0

Could the maintainers create a new release with the electron 5/6 prebuilds?