### PR TITLE
Fix for V8 release v7.8.

### DIFF
--- a/src/device.cc
+++ b/src/device.cc
@@ -75,7 +75,7 @@ static NAN_METHOD(deviceConstructor) {
 	if (ret > 0) {
 		Local<Array> array = Nan::New<Array>(ret);
 		for (int i = 0; i < ret; ++ i) {
-			array->Set(i, Nan::New(port_numbers[i]));
+			Nan::Set(array, i, Nan::New(port_numbers[i]));
 		}
 		Nan::DefineOwnProperty(info.This(), V8SYM("portNumbers"), array, CONST_PROP);
 	}
@@ -106,14 +106,14 @@ Local<Object> Device::cdesc2V8(libusb_config_descriptor * cdesc){
 		int numAltSettings = cdesc->interface[idxInterface].num_altsetting;
 
 		Local<Array> v8altsettings = Nan::New<Array>(numAltSettings);
-		v8interfaces->Set(idxInterface, v8altsettings);
+		Nan::Set(v8interfaces, idxInterface, v8altsettings);
 
 		for (int idxAltSetting = 0; idxAltSetting < numAltSettings; idxAltSetting++) {
 			const libusb_interface_descriptor& idesc =
 				cdesc->interface[idxInterface].altsetting[idxAltSetting];
 
 			Local<Object> v8idesc = Nan::New<Object>();
-			v8altsettings->Set(idxAltSetting, v8idesc);
+			Nan::Set(v8altsettings, idxAltSetting, v8idesc);
 
 			STRUCT_TO_V8(v8idesc, idesc, bLength)
 			STRUCT_TO_V8(v8idesc, idesc, bDescriptorType)
@@ -135,7 +135,7 @@ Local<Object> Device::cdesc2V8(libusb_config_descriptor * cdesc){
 				const libusb_endpoint_descriptor& edesc = idesc.endpoint[idxEndpoint];
 
 				Local<Object> v8edesc = Nan::New<Object>();
-				v8endpoints->Set(idxEndpoint, v8edesc);
+				Nan::Set(v8endpoints, idxEndpoint, v8edesc);
 
 				STRUCT_TO_V8(v8edesc, edesc, bLength)
 				STRUCT_TO_V8(v8edesc, edesc, bDescriptorType)
@@ -172,7 +172,7 @@ NAN_METHOD(Device_GetAllConfigDescriptors){
 	Local<Array> v8cdescriptors = Nan::New<Array>(dd.bNumConfigurations);
 	for(uint8_t i = 0; i < dd.bNumConfigurations; i++){
 		libusb_get_config_descriptor(self->device, i, &cdesc);
-		v8cdescriptors->Set(i, Device::cdesc2V8(cdesc));
+		Nan::Set(v8cdescriptors, i, Device::cdesc2V8(cdesc));
 		libusb_free_config_descriptor(cdesc);
 	}
 	info.GetReturnValue().Set(v8cdescriptors);
@@ -412,5 +412,5 @@ void Device::Init(Local<Object> target){
 	Nan::SetPrototypeMethod(tpl, "__attachKernelDriver", AttachKernelDriver);
 
 	device_constructor.Reset(tpl);
-	target->Set(Nan::New("Device").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
+	Nan::Set(target, Nan::New("Device").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
 }

--- a/src/node_usb.cc
+++ b/src/node_usb.cc
@@ -63,7 +63,7 @@ extern "C" void Initialize(Local<Object> target) {
 
 	// Initialize libusb. On error, halt initialization.
 	int res = libusb_init(&usb_context);
-	target->Set(Nan::New<String>("INIT_ERROR").ToLocalChecked(), Nan::New<Number>(res));
+	Nan::Set(target, Nan::New<String>("INIT_ERROR").ToLocalChecked(), Nan::New<Number>(res));
 	if (res != 0) {
 		return;
 	}
@@ -113,7 +113,7 @@ NAN_METHOD(GetDeviceList) {
 	Local<Array> arr = Nan::New<Array>(cnt);
 
 	for(int i = 0; i < cnt; i++) {
-		arr->Set(i, Device::get(devs[i]));
+		Nan::Set(arr, i, Device::get(devs[i]));
 	}
 	libusb_free_device_list(devs, true);
 	info.GetReturnValue().Set(arr);
@@ -298,6 +298,6 @@ void initConstants(Local<Object> target){
 Local<Value> libusbException(int errorno) {
 	const char* err = libusb_error_name(errorno);
 	Local<Value> e  = Nan::Error(err);
-	e.As<v8::Object>()->Set(Nan::New<String>("errno").ToLocalChecked(), Nan::New<Integer>(errorno));
+	Nan::Set(e.As<v8::Object>(), Nan::New<String>("errno").ToLocalChecked(), Nan::New<Integer>(errorno));
 	return e;
 }

--- a/src/transfer.cc
+++ b/src/transfer.cc
@@ -153,5 +153,5 @@ void Transfer::Init(Local<Object> target){
 	Nan::SetPrototypeMethod(tpl, "submit", Transfer_Submit);
 	Nan::SetPrototypeMethod(tpl, "cancel", Transfer_Cancel);
 
-	target->Set(Nan::New("Transfer").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
+	Nan::Set(target, Nan::New("Transfer").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
 }


### PR DESCRIPTION
Replace calls to the deprecated and now removed v8::Object::Set(...) calls with Nan::Set(Object, ...).

Builds with Node 12.8 #337 and Electron 7 #336.
