### PR TITLE
[work in progress] Add arm64 prebuilds to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ env:
   - PREBUILD_TARGETS="6.0.0 8.0.0 10.0.0 12.0.0 13.0.0"
     # Supported Electron versions: https://electronjs.org/docs/tutorial/electron-timelines
   - PREBUILD_ELECTRON_TARGETS="4.0.4 5.0.0 6.0.0 7.0.0"
-  matrix:
-  - ARCH="x64"
-  - ARCH="ia32"
-  - ARCH="arm64"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: cpp
 
+arch:
+  - amd64
+  - arm64
+
 os:
 - linux
 - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,23 @@ env:
   - ARCH="arm64"
 
 matrix:
+  include:
+    - os: windows
+      env: ARCH="x64"
+      arch: amd64
+    - os: windows
+      env: ARCH="ia32"
+      arch: amd64
+    - os: osx
+      env: ARCH="x64"
+      arch: amd64
+    - os: linux
+      env: ARCH="x64"
+      arch: amd64
+    - os: linux
+      env: ARCH="arm64"
+      arch: arm64
+
   exclude:
   - os: linux
     env: ARCH="ia32"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
   matrix:
   - ARCH="x64"
   - ARCH="ia32"
+  - ARCH="arm64"
 
 matrix:
   exclude:
@@ -28,6 +29,10 @@ matrix:
     env: ARCH="ia32"
   - os: osx
     env: ARCH="ia32"
+  - os: osx
+    env: ARCH="arm64"
+  - os: windows
+    env: ARCH="arm64"
 
 before_install:
 - |


### PR DESCRIPTION
Compiling node-usb on Raspberry Pi is not all that friendly. Prebuilds would be a useful addition if Travis plays along.

This is a work in progress. I'm still sorting out how to test Travis builds from a fork.

