### PR TITLE
Update prebuild version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "coffeescript": "~2.4.1",
     "mocha": "~6.1.4",
-    "prebuild": "^8.2.1"
+    "prebuild": "^9.1.1"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Explanation from the prebuild repo:

Since electron and node are reusing the versions now (fx 6.0.0) and node-gyp only uses the version to store the dev files, they have started clashing. This new version of prebuild has a fix for it.