### PR TITLE
Add prebuild for Electron 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     # Supported Node versions: https://nodejs.org/en/about/releases/
   - PREBUILD_TARGETS="6.0.0 8.0.0 10.0.0 12.0.0 13.0.0"
     # Supported Electron versions: https://electronjs.org/docs/tutorial/electron-timelines
-  - PREBUILD_ELECTRON_TARGETS="4.0.4 5.0.0 6.0.0 7.0.0"
+  - PREBUILD_ELECTRON_TARGETS="4.0.4 5.0.0 6.0.0 7.0.0 8.0.0"
   matrix:
   - ARCH="x64"
   - ARCH="ia32"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1542,9 +1542,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.12.0.tgz",
-      "integrity": "sha512-VhPBXCIcvmo/5K8HPmnWJyyhvgKxnHTUMXR/XwGHV68+wrgkzST4UmQrY/XszSWA5dtnXpNp528zkcyJ/pzVcw==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.15.0.tgz",
+      "integrity": "sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==",
       "requires": {
         "semver": "^5.4.1"
       }


### PR DESCRIPTION
Adds prebuild for Electron 8 (https://github.com/lgeiger/node-abi/blob/14ee3eb65cdd51cc0dd0b7fa3220b07451a02ef9/index.js#L76)

Fixes #353﻿
