### PR TITLE
Add prebuild for Electron 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     # Supported Node versions: https://nodejs.org/en/about/releases/
   - PREBUILD_TARGETS="6.0.0 8.0.0 10.0.0 12.0.0 13.0.0"
     # Supported Electron versions: https://electronjs.org/docs/tutorial/electron-timelines
-  - PREBUILD_ELECTRON_TARGETS="4.0.4 5.0.0 6.0.0 7.0.0 8.0.0"
+  - PREBUILD_ELECTRON_TARGETS="4.0.4 5.0.0 6.0.0 7.0.0 8.0.0 9.0.0"
   matrix:
   - ARCH="x64"
   - ARCH="ia32"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1542,9 +1542,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.15.0.tgz",
-      "integrity": "sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.17.0.tgz",
+      "integrity": "sha512-dFRAA0ACk/aBo0TIXQMEWMLUTyWYYT8OBYIzLmEUrQTElGRjxDCvyBZIsDL0QA7QCaj9PrawhOmTEdsuLY4uOQ==",
       "requires": {
         "semver": "^5.4.1"
       }


### PR DESCRIPTION
Following suit with [this PR](https://github.com/tessel/node-usb/pull/354), this PR adds support for Electron 9.

Here is the [associated node-abi update](https://github.com/lgeiger/node-abi/commit/8934a47f029c0f6fafc3ef1eeea26adb028f5c6b#diff-168726dbe96b3ce427e7fedce31bb0bc)