### PR TITLE
Adds NodeJS 14 to prebuild target and removes 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 env:
   global:
     # Supported Node versions: https://nodejs.org/en/about/releases/
-  - PREBUILD_TARGETS="6.0.0 8.0.0 10.0.0 12.0.0 13.0.0"
+  - PREBUILD_TARGETS="6.0.0 8.0.0 10.0.0 12.0.0 14.0.0"
     # Supported Electron versions: https://electronjs.org/docs/tutorial/electron-timelines
   - PREBUILD_ELECTRON_TARGETS="4.0.4 5.0.0 6.0.0 7.0.0 8.0.0 9.0.0"
   matrix:


### PR DESCRIPTION
NodeJS 13 is now official end of life and NodeJS 14 is officially Current.  Looking at the prebuild target history, it appears that odd numbered versions (beta builds) aren't maintained so I dropped NodeJS 13 support and added 14 support.