### PR TITLE
Bumped the standard version to C++14 for latest V8

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,7 +12,7 @@
         './src/transfer.cc',
       ],
       'cflags_cc': [
-        '-std=c++0x'
+        '-std=c++14'
       ],
       'defines': [
         '_FILE_OFFSET_BITS=64',


### PR DESCRIPTION
Hi!
Thanks for this awesome library, I'm using it in my app built on Electron as a native module. Latest V8, as well as Electron, require `std=c++14`, otherwise this error is thrown:

```
2020-11-19T14:26:52.8560846Z /home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/include/node/v8-internal.h:418:38: error: ‘remove_cv_t’ is not a member of ‘std’
2020-11-19T14:26:52.8562332Z              !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
2020-11-19T14:26:52.8562962Z                                       ^~~~~~~~~~~
```

<details>
<summary>Full error log</summary>

```
2020-11-19T14:26:52.5780752Z   g++ -o Release/obj.target/usb_bindings/src/node_usb.o ../src/node_usb.cc '-DNODE_GYP_MODULE_NAME=usb_bindings' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DV8_COMPRESS_POINTERS' '-DV8_31BIT_SMIS_ON_64BIT_ARCH' '-DV8_REVERSE_JSARGS' '-D__STDC_FORMAT_MACROS' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DBUILDING_NODE_EXTENSION' -I../src -I../../nan -I/home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/include/node -I/home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/src -I/home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/deps/openssl/config -I/home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/deps/openssl/openssl/include -I/home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/deps/uv/include -I/home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/deps/zlib -I/home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/deps/v8/include -I../libusb/libusb  -fPIC -pthread -Wall -Wextra -Wno-unused-parameter -m64 -O3 -fno-omit-frame-pointer -fno-rtti -fno-exceptions -std=gnu++1y -std=c++0x -MMD -MF ./Release/.deps/Release/obj.target/usb_bindings/src/node_usb.o.d.raw   -c
2020-11-19T14:26:52.8531926Z In file included from /home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/include/node/v8.h:30:0,
2020-11-19T14:26:52.8539748Z                  from ../src/node_usb.h:12,
2020-11-19T14:26:52.8540713Z                  from ../src/node_usb.cc:1:
2020-11-19T14:26:52.8544484Z /home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/include/node/v8-internal.h: In function ‘void v8::internal::PerformCastCheck(T*)’:
2020-11-19T14:26:52.8560846Z /home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/include/node/v8-internal.h:418:38: error: ‘remove_cv_t’ is not a member of ‘std’
2020-11-19T14:26:52.8562332Z              !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
2020-11-19T14:26:52.8562962Z                                       ^~~~~~~~~~~
2020-11-19T14:26:52.8564637Z /home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/include/node/v8-internal.h:418:38: note: suggested alternative: ‘remove_cv’
2020-11-19T14:26:52.8565990Z              !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
2020-11-19T14:26:52.8566699Z                                       ^~~~~~~~~~~
2020-11-19T14:26:52.8567137Z                                       remove_cv
2020-11-19T14:26:52.8568557Z /home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/include/node/v8-internal.h:418:38: error: ‘remove_cv_t’ is not a member of ‘std’
2020-11-19T14:26:52.8570682Z /home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/include/node/v8-internal.h:418:38: note: suggested alternative: ‘remove_cv’
2020-11-19T14:26:52.8572047Z              !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
2020-11-19T14:26:52.8607919Z                                       ^~~~~~~~~~~
2020-11-19T14:26:52.8608452Z                                       remove_cv
2020-11-19T14:26:52.8610410Z /home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/include/node/v8-internal.h:418:50: error: template argument 2 is invalid
2020-11-19T14:26:52.8611708Z              !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
2020-11-19T14:26:52.8612260Z                                                   ^
2020-11-19T14:26:52.8613974Z /home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/include/node/v8-internal.h:418:63: error: ‘::Perform’ has not been declared
2020-11-19T14:26:52.8615251Z              !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
2020-11-19T14:26:52.8615800Z                                                                ^~~~~~~
2020-11-19T14:26:52.8617257Z /home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/include/node/v8-internal.h:418:63: note: suggested alternative: ‘perror’
2020-11-19T14:26:52.8618721Z              !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
2020-11-19T14:26:52.8619301Z                                                                ^~~~~~~
2020-11-19T14:26:52.8620975Z                                                                perror
2020-11-19T14:26:52.9181362Z In file included from ../src/node_usb.h:12:0,
2020-11-19T14:26:52.9181996Z                  from ../src/node_usb.cc:1:
2020-11-19T14:26:52.9183706Z /home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/include/node/v8.h: At global scope:
2020-11-19T14:26:52.9186100Z /home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/include/node/v8.h:9182:75: warning: ‘MicrotasksCompletedCallback’ is deprecated [-Wdeprecated-declarations]
2020-11-19T14:26:52.9188214Z    void AddMicrotasksCompletedCallback(MicrotasksCompletedCallback callback);
2020-11-19T14:26:52.9189700Z                                                                            ^
2020-11-19T14:26:52.9191594Z /home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/11.0.1/include/node/v8.h:9190:78: warning: ‘MicrotasksCompletedCallback’ is deprecated [-Wdeprecated-declarations]
2020-11-19T14:26:52.9193765Z    void RemoveMicrotasksCompletedCallback(MicrotasksCompletedCallback callback);
2020-11-19T14:26:52.9194858Z                                                                               ^
2020-11-19T14:26:53.0606786Z ../src/node_usb.cc: In function ‘void handleHotplug(std::pair<libusb_device*, libusb_hotplug_event>)’:
2020-11-19T14:26:53.0608754Z ../src/node_usb.cc:151:58: warning: ‘v8::Local<v8::Value> Nan::MakeCallback(v8::Local<v8::Object>, const char*, int, v8::Local<v8::Value>*)’ is deprecated [-Wdeprecated-declarations]
2020-11-19T14:26:53.0609998Z   Nan::MakeCallback(Nan::New(hotplugThis), "emit", 2, argv);
2020-11-19T14:26:53.0610560Z                                                           ^
2020-11-19T14:26:53.0611089Z In file included from ../src/helpers.h:3:0,
2020-11-19T14:26:53.0611627Z                  from ../src/node_usb.h:21,
2020-11-19T14:26:53.0612103Z                  from ../src/node_usb.cc:1:
2020-11-19T14:26:53.0612612Z ../../nan/nan.h:1001:46: note: declared here
2020-11-19T14:26:53.0613287Z    NAN_DEPRECATED inline v8::Local<v8::Value> MakeCallback(
2020-11-19T14:26:53.0613864Z                                               ^~~~~~~~~~~~
2020-11-19T14:26:53.1741922Z make: *** [Release/obj.target/usb_bindings/src/node_usb.o] Error 1
2020-11-19T14:26:53.1744402Z usb_bindings.target.mk:128: recipe for target 'Release/obj.target/usb_bindings/src/node_usb.o' failed
2020-11-19T14:26:53.1746011Z make: Leaving directory '/home/runner/work/keeweb-native-modules/keeweb-native-modules/node_modules/usb/build'
2020-11-19T14:26:53.1751462Z ✖ Rebuild Failed
2020-11-19T14:26:53.1757771Z 
2020-11-19T14:26:53.1772714Z An unhandled error occurred inside electron-rebuild
```
</details>

I can't find any official reference about this requirement, but here's a [question](https://stackoverflow.com/questions/64769506/does-googles-v8-require-c14-standard) on StackOverflow, and there are several issues about it on GitHub that make me think C++14 is a hard requirement for V8.

This PR bumps the standard version to C++14. It works for me on Linux, macOS, and Windows.