### PR TITLE
Added node-gyp options for node14 ci-build 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 - osx
 - windows
 
-dist: trusty
+dist: bionic
 
 addons:
   apt:

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,5 +1,7 @@
 {
   'variables': {
+		'v8_enable_pointer_compression': 0,
+		'v8_enable_31bit_smis_on_64bit_arch': 0,
     'use_udev%': 1,
     'use_system_libusb%': 'false',
   },

--- a/libusb.gypi
+++ b/libusb.gypi
@@ -1,5 +1,7 @@
 {
   'variables': {
+		'v8_enable_pointer_compression': 0,
+		'v8_enable_31bit_smis_on_64bit_arch': 0,
     'use_udev%': 1,
   },
   'targets': [


### PR DESCRIPTION
I found that there is no Node.js 14 prebuild binary(travis says 'passed' but actually 'failed' only node.js 14). This build problem occurs when building Node14 with older Nodejs versions. I added two options ('v8_enable_pointer_compression': 0, 'v8_enable_31bit_smis_on_64bit_arch': 0,) to binding.gyp and libusb.gypi.

In addition for future V8 compatibility, the [PR#394](https://github.com/tessel/node-usb/pull/394) is needed to apply.
But current travis-ci contaner use ubuntu trusty, that has old g++ that doesn't support c++14. So I upgrade trusty(14.04) to bionic(18.04). The reason why I didn't upgrade to focal(20.04) is that, focal is based on the Python3 and therefore there is more to fix. I will make another PR for that issue.