### PR TITLE
Python3 compliant for ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 - osx
 - windows
 
-dist: trusty
+dist: bionic
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: cpp
 
+sudo: required
+
 os:
 - linux
 - osx
 - windows
 
-dist: bionic
+dist: focal
 
 addons:
   apt:
@@ -38,6 +40,7 @@ before_install:
   fi
 - $CXX --version
 - node --version
+- npm update -g npm
 - npm --version
 
 install:

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,5 +1,7 @@
 {
   'variables': {
+		'v8_enable_pointer_compression': 0,
+		'v8_enable_31bit_smis_on_64bit_arch': 0,
     'use_udev%': 1,
     'use_system_libusb%': 'false',
   },

--- a/libusb.gypi
+++ b/libusb.gypi
@@ -1,5 +1,7 @@
 {
   'variables': {
+		'v8_enable_pointer_compression': 0,
+		'v8_enable_31bit_smis_on_64bit_arch': 0,
     'use_udev%': 1,
   },
   'targets': [

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "coffeescript": "~2.4.1",
     "mocha": "~6.1.4",
-    "prebuild": "^9.1.1"
+    "prebuild": "^10.0.1"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
This PR migtates travis ci build enviroment from deprecated python2 to python3. Followings are changed.

- To use pyhon3 for default, simplly I changed ubuntu version to focal(20.04). I think it will work on older ubuntu distributions, but changing the default python to python3 makes the build script more complex.
- Upgrade npm that requires older node-gyp which doesn't support python3. This operation requires root privilage.
- Upgrade rebuild that requires older node-gyp which doesn't support python3.