### PR TITLE
Update prebuilds to include Electron 11 and 12-beta

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -34,7 +34,7 @@ jobs:
       # Supported Node versions: https://nodejs.org/en/about/releases/
       - run: npm run prebuild -- -t 8.0.0 -t 10.0.0 -t 12.0.0 -t 14.0.0 -a ${{ matrix.config.arch }}
       # Supported Electron versions: https://electronjs.org/docs/tutorial/electron-timelines
-      - run: npm run prebuild -- -t 4.0.4 -t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -r electron -a ${{ matrix.config.arch }}
+      - run: npm run prebuild -- -t 4.0.4 -t 5.0.0 -t 6.0.0 -t 7.0.0 -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0-beta.1 -r electron -a ${{ matrix.config.arch }}
       - if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         env:

--- a/binding.gyp
+++ b/binding.gyp
@@ -12,7 +12,7 @@
         './src/transfer.cc',
       ],
       'cflags_cc': [
-        '-std=c++0x'
+        '-std=c++14'
       ],
       'defines': [
         '_FILE_OFFSET_BITS=64',

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "devDependencies": {
     "coffeescript": "~2.4.1",
     "mocha": "~6.1.4",
-    "prebuild": "^10.0.0"
+    "node-abi": "^2.19.3",
+    "prebuild": "^10.0.1"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
This PR introduces prebuild support for:

- Electron 11.0.0
- Electron 12.0.0-beta.1 (12.0.0 isn't yet stable)

It supercedes #400, #394 and #376, thanks to @pavinthan, @NoahAndrews and especially @antelle for the c++ fix.

@kevinmehall would you be happy to close the PRs above once this is merged and consider a new release?