### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/helpers.h
+++ b/src/helpers.h
@@ -3,7 +3,9 @@
 
 #define THROW_BAD_ARGS(FAIL_MSG) throw Napi::TypeError::New(env, FAIL_MSG);
 #define THROW_ERROR(FAIL_MSG) throw Napi::Error::New(env, FAIL_MSG);
-#define CHECK_N_ARGS(MIN_ARGS) if (info.Length() < MIN_ARGS) { THROW_BAD_ARGS("Expected " #MIN_ARGS " arguments") }
+
+#pragma GCC diagnostic ignored "-Wtype-limits"
+#define CHECK_N_ARGS(MIN_ARGS) if ((MIN_ARGS) > 0 && info.Length() < (MIN_ARGS)) { THROW_BAD_ARGS("Expected " #MIN_ARGS " arguments") }
 
 const napi_property_attributes CONST_PROP = static_cast<napi_property_attributes>(napi_enumerable | napi_configurable);
 

--- a/src/node_usb.h
+++ b/src/node_usb.h
@@ -28,6 +28,8 @@ struct Device: public Napi::ObjectWrap<Device> {
 	libusb_device* device;
 	libusb_device_handle* device_handle;
 
+	int refs_;
+
 #ifndef USE_POLL
 	UVQueue<Transfer*> completionQueue;
 #endif
@@ -38,8 +40,6 @@ struct Device: public Napi::ObjectWrap<Device> {
 	inline void ref(){ refs_ = Ref();}
 	inline void unref(){ refs_ = Unref();}
 	inline bool canClose(){return refs_ == 0;}
-
-	int refs_;
 
 	Device(const Napi::CallbackInfo& info);
 	~Device();


### PR DESCRIPTION
Fixing/ignoring compiler warnings (on Ubuntu) to reduce clutter.

- Before: https://github.com/tessel/node-usb/runs/2313113186#step:5:10
- After: https://github.com/tessel/node-usb/runs/2500923044#step:5:10