### PR TITLE
Update repository reference

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -308,7 +308,7 @@ Development and testing
 
 To build from git:
 
-	git clone --recursive https://github.com/nonolith/node-usb.git
+	git clone --recursive https://github.com/tessel/node-usb.git
 	cd node-usb
 	npm install
 


### PR DESCRIPTION
- The `node-usb` repository changed owner on Github.
- The old repository location (at Nonolith Labs) redirects to the new location (at Tessel).

See

- https://github.com/nonolith
- https://github.com/nonolith/node-usb
- https://github.com/tessel
- https://github.com/tessel/node-usb