### PR TITLE
fix invalid initial refs

### DIFF
--- a/src/device.cc
+++ b/src/device.cc
@@ -11,7 +11,7 @@
 
 Napi::FunctionReference Device::constructor;
 
-Device::Device(const Napi::CallbackInfo & info) : Napi::ObjectWrap<Device>(info), device_handle(0), refs_(1)
+Device::Device(const Napi::CallbackInfo & info) : Napi::ObjectWrap<Device>(info), device_handle(0), refs_(0)
 #ifndef USE_POLL
 , completionQueue(handleCompletion)
 #endif


### PR DESCRIPTION
it's impossible to close() a device just after open(), you'll always get: `Error: Can't close device with a pending request`

refs should be set initially to 0, since [napi_wrap() returns a weak reference](https://nodejs.org/api/n-api.html#n_api_napi_wrap)