### PR TITLE
Update libusb submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libusb"]
 	path = libusb
-	url = https://github.com/kevinmehall/libusb.git
+	url = https://github.com/node-usb/libusb.git


### PR DESCRIPTION
Update submodule URL following https://github.com/node-usb/libusb/pull/2#issuecomment-925122061

Correct branch/commit is retained.