### PR TITLE
Add cleanup macro option after libusb failure

### DIFF
--- a/src/hotplug.cc
+++ b/src/hotplug.cc
@@ -21,7 +21,7 @@ class HotPlugManagerLibUsb: public HotPlugManager {
 
     void enableHotplug(const Napi::Env& env, ModuleData* instanceData) {
         libusb_context* usb_context = instanceData->usb_context;
-        CHECK_USB(libusb_hotplug_register_callback(
+        CHECK_USB_CLEANUP(libusb_hotplug_register_callback(
             usb_context,
             (libusb_hotplug_event)(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED | LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT),
             (libusb_hotplug_flag)0,
@@ -31,7 +31,10 @@ class HotPlugManagerLibUsb: public HotPlugManager {
             hotplug_callback,
             instanceData,
             &hotplugHandle
-        ));
+        ), {
+            instanceData->hotplugQueue.stop();
+            instanceData->hotplugThis.Reset();
+        });
     }
 
     void disableHotplug(const Napi::Env& env, ModuleData* instanceData) {

--- a/src/node_usb.h
+++ b/src/node_usb.h
@@ -106,10 +106,16 @@ private:
 
 
 
-#define CHECK_USB(r) \
-    if (r < LIBUSB_SUCCESS) { \
-        throw libusbException(env, r); \
-    }
+#define CHECK_USB_CLEANUP(r, cleanup) \
+    do { \
+        int _r = (r); \
+        if (_r < LIBUSB_SUCCESS) { \
+            cleanup \
+            throw libusbException(env, _r); \
+        } \
+    } while (0)
+
+#define CHECK_USB(r) CHECK_USB_CLEANUP(r, {})
 
 #define CALLBACK_ARG(CALLBACK_ARG_IDX) \
     Napi::Function callback; \

--- a/src/transfer.cc
+++ b/src/transfer.cc
@@ -73,7 +73,11 @@ Napi::Value Transfer::Submit(const Napi::CallbackInfo& info) {
         self->transfer->buffer
     );
 
-    CHECK_USB(libusb_submit_transfer(self->transfer));
+    CHECK_USB_CLEANUP(libusb_submit_transfer(self->transfer), {
+        self->v8buffer.Reset();
+        self->transfer->buffer = NULL;
+        self->transfer->length = 0;
+    });
     self->ref();
     self->device->ref();
 


### PR DESCRIPTION
## Changes
<!-- Describe the changes this PR introduces -->
- Added macro which allows cleanup after USB failure
- Added this to transfer and hotplug commands which need post-tidying

## Fixes
<!-- List the GitHub issues this PR resolves -->
- #961 

## Checklist
<!-- Put an `x` in the boxes that apply -->
Have you...

- [ ] Tested the change acts as expected
- [ ] Checked the change doesn't remove or change existing functionality
- [ ] Considered how the feature impacts the product and tested around it (not just the happy paths)
- [ ] Where possible, executed the hardware tests on multiple operating systems
